### PR TITLE
Bug Fix: Correct ALU operation for signed numbers.

### DIFF
--- a/rtl/core/alu.sv
+++ b/rtl/core/alu.sv
@@ -36,9 +36,9 @@ always_comb begin : ALU_LOGIC
         EQUAL: ALU_RD_o = (ALU_RS1_i == ALU_RS2_i) ? 32'h1 : 32'h0;
         
         // Comparações
-        SLT:             ALU_RD_o = (ALU_RS1_i < ALU_RS2_i) ? 32'h1 : 32'h0;
+        SLT:             ALU_RD_o = ($signed(ALU_RS1_i) < $signed(ALU_RS2_i)) ? 32'h1 : 32'h0;
         SLT_U:           ALU_RD_o = ($unsigned(ALU_RS1_i) < $unsigned(ALU_RS2_i)) ? 32'h1 : 32'h0;
-        GREATER_EQUAL:   ALU_RD_o = (ALU_RS1_i >= ALU_RS2_i) ? 32'h1 : 32'h0;
+        GREATER_EQUAL:   ALU_RD_o = ($signed(ALU_RS1_i) >= $signed(ALU_RS2_i)) ? 32'h1 : 32'h0;
         GREATER_EQUAL_U: ALU_RD_o = ($unsigned(ALU_RS1_i) >= $unsigned(ALU_RS2_i)) ? 32'h1 : 32'h0;
         
         // Shifts


### PR DESCRIPTION
# Bug Fix
First of all, congratulations for your work on the Risco-5 family. It sure inspires other students to learn and develop using the RISC-V ISA.

## The Issue
Grande-Risco-5 failed in the test for BLT in the [riscv-arch-test](https://github.com/riscv-non-isa/riscv-arch-test) suite. The processor fails when executing the instruction with negative operands.

## How to Reproduce
This piece of code is enough to reproduce the error.
```
230: li	a4, 4
234: lui a1, 0xe0000
238: addi a1, a1, -1 # dfffffff
23c: li a2, 0
240: blt a4, a1, 24c
244: addi a2, a2, 2
248: j 254
24c: addi a2, a2, 3
250: j 254
254: sw a2, 4(t0)
```

## The Fix
It turns out the ALU is performing the operation with the arguments as unsigned numbers. I changed that in the code.